### PR TITLE
Configure electron-builder for portable Windows build

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,9 +64,9 @@ npm start
 The application window will open and you can enter the serial port, send commands and see live status updates in the log panel.
 
 ## Building
-To create a packaged application for Windows x64 run:
+To create a standalone portable executable for Windows run:
 ```bash
-npm run build
+npm run dist
 ```
-The output will be placed in a `fosca-pump-win32-x64` directory inside `desktop`.
+The output will be placed in the `dist` folder as `desktop-<version>-portable.exe`.
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "build": "electron-packager . fosca-pump --platform=win32 --arch=x64 --overwrite"
+    "build": "electron-packager . fosca-pump --platform=win32 --arch=x64 --overwrite",
+    "dist": "electron-builder --win portable"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +17,21 @@
   },
   "devDependencies": {
     "electron": "^27.0.0",
-    "electron-packager": "^17.1.0"
+    "electron-packager": "^17.1.0",
+    "electron-builder": "^24.6.0"
+  },
+  "build": {
+    "win": {
+      "target": [
+        "portable"
+      ]
+    },
+    "nsis": {
+      "oneClick": true,
+      "perMachine": false
+    },
+    "portable": {
+      "artifactName": "${productName}-${version}-portable.${ext}"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- configure electron-builder in `desktop/package.json`
- document new `npm run dist` step in README

## Testing
- `npm install`
- `npm run dist` *(fails: wine is required)*

------
https://chatgpt.com/codex/tasks/task_e_6877c10d0990832f8a572dffd9f430dd