### PR TITLE
Ignore Lazarus build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 desktop/node_modules/
+# Lazarus/FreePascal build outputs
+lib/
+*.o
+*.ppu
+*.exe
+
+# Electron build output
+desktop/dist/


### PR DESCRIPTION
## Summary
- ignore Lazarus/FreePascal build artifacts (`lib/`, `*.o`, `*.ppu`, executable files)
- ignore Electron build outputs in `desktop/dist/`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877cca6b1d8832fbf7b9f6498845422