### PR TITLE
Clarify Wine dependency for Linux build

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,5 +68,7 @@ To create a standalone portable executable for Windows run:
 ```bash
 npm run dist
 ```
+When building on Linux, ensure that Wine is installed because `electron-builder`
+needs it to generate Windows binaries.
 The output will be placed in the `dist` folder as `desktop-<version>-portable.exe`.
 


### PR DESCRIPTION
## Summary
- note Wine requirement for `npm run dist`

## Testing
- `npm install` in `desktop`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877c890e058832f9c719c0b8967864c