### PR TITLE
Add LGPL headers

### DIFF
--- a/AboutForm.pas
+++ b/AboutForm.pas
@@ -1,3 +1,7 @@
+{*
+  Fosca Driver
+  Licensed under the GNU LGPLv3. See the LICENSE file in this repository.
+*}
 unit AboutForm;
 
 {$mode objfpc}{$H+}

--- a/JTPumpDriver3.lpr
+++ b/JTPumpDriver3.lpr
@@ -1,3 +1,7 @@
+{*
+  Fosca Driver
+  Licensed under the GNU LGPLv3. See the LICENSE file in this repository.
+*}
 program JTPumpDriver3;
 
 {$mode objfpc}{$H+}

--- a/JTPumpDriverMain3.pas
+++ b/JTPumpDriverMain3.pas
@@ -1,3 +1,7 @@
+{*
+  Fosca Driver
+  Licensed under the GNU LGPLv3. See the LICENSE file in this repository.
+*}
 unit JTPumpDriverMain3;
 
 {$mode objfpc}{$H+}{$R+}{$Q+}

--- a/PumpNameSetting.pas
+++ b/PumpNameSetting.pas
@@ -1,3 +1,7 @@
+{*
+  Fosca Driver
+  Licensed under the GNU LGPLv3. See the LICENSE file in this repository.
+*}
 unit PumpNameSetting;
 
 {$mode objfpc}{$H+}

--- a/ScanningProgress.pas
+++ b/ScanningProgress.pas
@@ -1,3 +1,7 @@
+{*
+  Fosca Driver
+  Licensed under the GNU LGPLv3. See the LICENSE file in this repository.
+*}
 unit ScanningProgress;
 
 {$mode ObjFPC}{$H+}

--- a/SerialUSBSelection.pas
+++ b/SerialUSBSelection.pas
@@ -1,3 +1,7 @@
+{*
+  Fosca Driver
+  Licensed under the GNU LGPLv3. See the LICENSE file in this repository.
+*}
 unit SerialUSBSelection;
 
 {$mode objfpc}{$H+}

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,3 +1,7 @@
+/*
+  Fosca Driver
+  Licensed under the GNU LGPLv3. See the LICENSE file in this repository.
+*/
 const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
 const pump = require('./serial/pumpDriver');

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -1,3 +1,7 @@
+/*
+  Fosca Driver
+  Licensed under the GNU LGPLv3. See the LICENSE file in this repository.
+*/
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('pumpAPI', {

--- a/desktop/renderer/renderer.js
+++ b/desktop/renderer/renderer.js
@@ -1,3 +1,7 @@
+/*
+  Fosca Driver
+  Licensed under the GNU LGPLv3. See the LICENSE file in this repository.
+*/
 const log = document.getElementById('log');
 const portInput = document.getElementById('port');
 const commandInput = document.getElementById('command');

--- a/desktop/serial/pumpDriver.js
+++ b/desktop/serial/pumpDriver.js
@@ -1,3 +1,7 @@
+/*
+  Fosca Driver
+  Licensed under the GNU LGPLv3. See the LICENSE file in this repository.
+*/
 const { SerialPort } = require('serialport');
 const EventEmitter = require('events');
 


### PR DESCRIPTION
## Summary
- add LGPLv3 header to Pascal sources
- add LGPLv3 header to Electron scripts

## Testing
- `npm install` (fails to compile due to warnings)
- `fpc JTPumpDriver3.lpr` *(fails: Can't find unit Interfaces)*

------
https://chatgpt.com/codex/tasks/task_e_6877ccb0360c832fa27c5b8018860b28