### PR TITLE
Document bossac license

### DIFF
--- a/LICENSE-bossac.txt
+++ b/LICENSE-bossac.txt
@@ -1,0 +1,5 @@
+This repository ships the bossac.exe utility from the Arduino project
+<https://github.com/arduino/arduino-flash-tools>. The executable is built
+from the BOSSA (Basic Open Source SAM-BA Application) sources available at
+<https://github.com/shumatech/BOSSA> which are distributed under the
+BSD 3-Clause license.

--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,7 @@ You can get the latest firmware version as binary from [here](https://github.com
 Copyright by Jobst Technologies.
 
 JT Pump Driver uses the Arduino tool [**bossac**](https://github.com/arduino/arduino-flash-tools).
+`bossac.exe` is built from the BOSSA project and distributed under the BSD 3-Clause license.
 
 # Compilation
 


### PR DESCRIPTION
## Summary
- document source and license of bossac.exe from Arduino
- mention BSD 3-Clause license in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877c88f0184832f87a44078af223035