### PR TITLE
Add workflow for automatic Windows release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install dependencies
+        working-directory: desktop
+        run: npm ci
+
+      - name: Build portable executable
+        working-directory: desktop
+        run: npm run dist
+
+      - name: Locate EXE
+        id: exe
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem "desktop/dist" -Filter *.exe | Select-Object -First 1
+          echo "path=$($exe.FullName)" >> $env:GITHUB_OUTPUT
+
+      - name: Create release for tag
+        if: github.event_name == 'push'
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+      - name: Determine release info
+        id: release
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "id=${{ steps.create_release.outputs.id }}" >> "$GITHUB_OUTPUT"
+            echo "upload_url=${{ steps.create_release.outputs.upload_url }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "id=${{ github.event.release.id }}" >> "$GITHUB_OUTPUT"
+            echo "upload_url=${{ github.event.release.upload_url }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release.outputs.upload_url }}
+          asset_path: ${{ steps.exe.outputs.path }}
+          asset_name: FOSCA-Pump-Driver-${{ github.ref_name }}-portable.exe
+          asset_content_type: application/octet-stream
+
+      - name: Annotate release with download link
+        uses: actions/github-script@v7
+        env:
+          RELEASE_ID: ${{ steps.release.outputs.id }}
+          EXE_NAME: FOSCA-Pump-Driver-${{ github.ref_name }}-portable.exe
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const release_id = Number(process.env.RELEASE_ID);
+            const exeName = process.env.EXE_NAME;
+            const tag = context.ref.replace('refs/tags/','');
+            const {owner, repo} = context.repo;
+            const downloadUrl = `https://github.com/${owner}/${repo}/releases/download/${tag}/${exeName}`;
+            const release = await github.rest.repos.getRelease({owner, repo, release_id});
+            let body = release.data.body || '';
+            if (!body.includes(downloadUrl)) {
+              body += `\n\n[Download portable EXE here](${downloadUrl})`;
+              await github.rest.repos.updateRelease({owner, repo, release_id, body});
+            }
+


### PR DESCRIPTION
## Summary
- add `.github/workflows/release.yml` workflow
- build portable Windows executable on tag or release
- upload EXE to GitHub release and annotate release with download link

## Testing
- `git commit -m "Add release workflow to build and upload portable exe"`

------
https://chatgpt.com/codex/tasks/task_e_687808bfb8dc832f8ba1b33a09c5935b