### PR TITLE
Fix electron builder config

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,7 +62,9 @@ Start Electron in development mode with:
 ```bash
 npm start
 ```
-The application window will open and you can enter the serial port, send commands and see live status updates in the log panel.
+The application window will open and you can enter the serial port, send commands
+and see live status updates in the log panel. The `npm start` script already
+passes `--no-sandbox` to Electron so it can run when executed as the `root` user.
 
 ## Building
 To create a standalone portable executable for Windows run:

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "electron --no-sandbox .",
     "build": "electron-packager . fosca-pump --platform=win32 --arch=x64 --overwrite",
     "dist": "electron-builder --win portable"
   },
@@ -21,7 +21,6 @@
     "electron-builder": "^24.6.0"
   },
   "build": {
-    "publisherName": "Fosca BioTech",
     "win": {
       "target": [
         "portable"


### PR DESCRIPTION
## Summary
- remove old `publisherName` config
- allow electron dev mode to run as root by passing `--no-sandbox`

## Testing
- `npm install`
- `npm run dist` *(fails: ERR_ELECTRON_BUILDER_CANNOT_EXECUTE)*
- `npm start` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_6878b1323b58832f80499243e779595f